### PR TITLE
Use cl-lib macro instead of cl.el

### DIFF
--- a/targets.el
+++ b/targets.el
@@ -163,7 +163,7 @@ times."
                                (unless (= (point) 1)
                                  (point)))))
              (when (= prev-paren last-pos)
-               (return-from nil))
+               (cl-return-from nil))
              (goto-char prev-paren)
              (when (and open-paren (= prev-paren open-paren))
                (re-search-backward quote-regexp nil t))


### PR DESCRIPTION
Block name of return must be specified in Emacs Lisp because
Emacs Lisp does not create nil block as Common Lisp. And cl-defun
must be used instead of defun at using cl-return-from.