### PR TITLE
closes #8: adds the targets-user-text-objects user option

### DIFF
--- a/README.org
+++ b/README.org
@@ -130,17 +130,18 @@ After targets has loaded, you can still add items to and remove items from =targ
 
 ** Example Use-package Setup
 #+begin_src emacs-lisp
-(use-package targets
-  :load-path "path/to/targets.el"
-  :init
-  (setq targets-pair-text-objects
-        '((paren "(" ")" pair :more-keys "b")
-          (bracket "[" "]" pair :more-keys "r")
-          (curly "{" "}" pair :more-keys "c")
-          (angle "<" ">" pair)))
-
-  :config
-  (targets-setup t))
+  (use-package targets
+    :load-path "path/to/targets.el"
+    :init
+    (setq targets-user-text-objects '((pipe "|" nil separator)
+                                      (paren "(" ")" pair :more-keys "b")
+                                      (bracket "[" "]" pair :more-keys "r")
+                                      (curly "{" "}" pair :more-keys "c")))
+    :config
+    (targets-setup t
+                   :inside-key nil
+                   :around-key nil
+                   :remote-key nil))
 #+end_src
 * Settings
 ** Avy Settings

--- a/targets.el
+++ b/targets.el
@@ -91,6 +91,10 @@ prior to the seek should be added to the jump list."
     (sentence 'evil-sentence nil object :keys "s")
     (paragraph 'evil-paragraph nil object :keys "p" :linewise t)))
 
+(defvar targets-user-text-objects nil
+  "Defines user text objects.
+These take precedence over text objects in `targets-text-objects'.")
+
 (defvar targets-text-objects
   (append targets-pair-text-objects
           targets-quote-text-objects
@@ -799,7 +803,11 @@ run."
                                                      :next-key next-key
                                                      :last-key last-key
                                                      :remote-key remote-key))))
-               targets-text-objects)))
+               (append targets-user-text-objects
+                       (cl-set-difference
+                        targets-text-objects
+                        targets-user-text-objects
+                        :key #'car)))))
 
 (provide 'targets)
 ;;; targets.el ends here


### PR DESCRIPTION
@noctuid, this is my newbie take on implementing the `targets-user-text-objects` option.

I'm using this with success with the following snippet:

```elisp
(use-package avy :ensure t)
  (with-eval-after-load "avy"
    (use-package targets :load-path "lisp/ninrod/targets.el"
      :init
      (setq targets-user-text-objects '((pipe "|" nil separator)
                                        (paren "(" ")" pair :more-keys "b")
                                        (bracket "[" "]" pair :more-keys "r")
                                        (curly "{" "}" pair :more-keys "c")))
      :config
      (targets-setup t
                     :inside-key nil
                     :around-key nil
                     :remote-key nil)))
```

I should point out that this is my very first serious elisp assignment and I've found that programming in elisp is actually fun and productive.